### PR TITLE
Make Logging Uniform Across Gateway Services

### DIFF
--- a/.org/vm-init-readme.org
+++ b/.org/vm-init-readme.org
@@ -145,6 +145,18 @@ or
   systemctl start docker.service
 #+END_SRC
 
+*** Logging
+    :PROPERTIES:
+    :CUSTOM_ID: h-E37376D1
+    :END:
+
+Set up standard logging directory:
+
+#+BEGIN_SRC shell :tangle '("../ubuntu-init.sh" "../centos-init.sh")
+  mkdir /logs
+  chown -R ${DOCKER_USER}:docker /logs
+#+END_SRC
+
 *** Reboot
     :PROPERTIES:
     :CUSTOM_ID: h-6D94F8D5

--- a/.org/vms/idd-archiver/readme.org
+++ b/.org/vms/idd-archiver/readme.org
@@ -246,7 +246,7 @@ While not related to IDD archival, the [[https://www.unidata.ucar.edu/software/t
 Create a logging directory for the TDM:
 
 #+BEGIN_SRC shell :tangle ../../../vms/idd-archiver/idd-archiver-install.sh
-  mkdir -p ~/logs/tdm
+  mkdir -p /logs/tdm
 #+END_SRC
 
 **** Running the TDM Out the TDM Log Directory
@@ -254,15 +254,15 @@ Create a logging directory for the TDM:
      :CUSTOM_ID: h-94768FE5
      :END:
 
-[[https://github.com/Unidata/tdm-docker#capturing-tdm-log-files-outside-the-container][TDM logging will not be configurable until TDS 5.0]]. Until then we are running the TDM out of the =~/logs/tdm= directory:
+[[https://github.com/Unidata/tdm-docker#capturing-tdm-log-files-outside-the-container][TDM logging will not be configurable until TDS 5.0]]. Until then we are running the TDM out of the =/logs/tdm= directory:
 
 #+BEGIN_SRC shell :tangle ../../../vms/idd-archiver/idd-archiver-install.sh
   curl -SL  \
        https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/4.6.13/tdmFat-4.6.13.jar \
-       -o ~/logs/tdm/tdm.jar
+       -o /logs/tdm/tdm.jar
   curl -SL https://raw.githubusercontent.com/Unidata/tdm-docker/master/tdm.sh \
-       -o ~/logs/tdm/tdm.sh
-  chmod +x  ~/logs/tdm/tdm.sh
+       -o /logs/tdm/tdm.sh
+  chmod +x  /logs/tdm/tdm.sh
 #+END_SRC
 
 *** Configuring the TDM to work with the TDS

--- a/.org/vms/idd-relay/readme.org
+++ b/.org/vms/idd-relay/readme.org
@@ -67,7 +67,7 @@ This =~/queues= directory will contain the LDM queue file.
   mkdir -p ~/queues
 #+END_SRC
 
-** ~/logs Directory
+** /logs Directory
    :PROPERTIES:
    :CUSTOM_ID: h-515DAD84
    :END:
@@ -76,7 +76,7 @@ This =~/queues= directory will contain the LDM queue file.
 Create the LDM =logs= directory.
 
 #+BEGIN_SRC shell :tangle ../../../vms/idd-relay/relay-install.sh
-  mkdir -p ~/logs/ldm
+  mkdir -p /logs/ldm
 #+END_SRC
 
 ** Port 388

--- a/.org/vms/ramadda/readme.org
+++ b/.org/vms/ramadda/readme.org
@@ -77,20 +77,9 @@ The =/repository= directory should be a fairly beefy data volume (e.g., 100 GBs)
 You will need an Apache Tomcat and RAMADDA log directories:
 
 #+BEGIN_SRC shell :tangle ../../../vms/ramadda/ramadda-install.sh
-   mkdir -p ~/logs/ramadda-tomcat/
-   mkdir -p ~/logs/ramadda/
+   mkdir -p /logs/ramadda-tomcat/
+   mkdir -p /logs/ramadda/
  #+END_SRC
-
-*** Scour log Directories
-    :PROPERTIES:
-    :CUSTOM_ID: h-1121D213
-    :END:
-
-Scour occasionally so the log directories do not fill up.
-
-#+BEGIN_SRC shell :tangle ../../../vms/ramadda/ramadda-install.sh
-  (crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
-#+END_SRC
 
 ** LDM Data Directory from idd-archiver Via NFS
    :PROPERTIES:

--- a/.org/vms/science-gateway/readme.org
+++ b/.org/vms/science-gateway/readme.org
@@ -58,10 +58,10 @@ With the help of Docker and ~docker-compose~, starting a VM containing an IDD ar
    :CUSTOM_ID: h-7FF2F781
    :END:
 
-The nginx log directory:
+Create the following nginx log directory:
 
 #+BEGIN_SRC shell
-  mkdir -p ~/logs/nginx/
+  mkdir -p /logs/nginx
  #+END_SRC
 
 ** Ports 80, 443

--- a/.org/vms/thredds-aws/readme.org
+++ b/.org/vms/thredds-aws/readme.org
@@ -97,20 +97,9 @@ Edit the =~/tdsconfig/threddsConfig.xml= to supply contact and host institution 
 You will need Apache Tomcat and TDS log directories:
 
  #+BEGIN_SRC shell :tangle ../../../vms/thredds-aws/thredds-aws-install.sh
-   mkdir -p ~/logs/tds-tomcat/
-   mkdir -p ~/logs/tds/
+   mkdir -p /logs/tds-tomcat/
+   mkdir -p /logs/tds/
  #+END_SRC
-
-*** Scour log Directories
-    :PROPERTIES:
-    :CUSTOM_ID: h-AC0813AF
-    :END:
-
-Scour occasionally so the log directories do not fill up.
-
-#+BEGIN_SRC shell :tangle ../../../vms/thredds-aws/thredds-aws-install.sh
-  (crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
-#+END_SRC
 
 ** S3Objects Directory
    :PROPERTIES:

--- a/.org/vms/thredds/readme.org
+++ b/.org/vms/thredds/readme.org
@@ -87,20 +87,9 @@ Edit the =~/tdsconfig/threddsConfig.xml= to supply contact and host institution 
 You will need Apache Tomcat and TDS log directories:
 
  #+BEGIN_SRC shell :tangle ../../../vms/thredds/thredds-install.sh
-   mkdir -p ~/logs/tds-tomcat/
-   mkdir -p ~/logs/tds/
+   mkdir -p /logs/tds-tomcat/
+   mkdir -p /logs/tds/
  #+END_SRC
-
-*** Scour log Directories
-    :PROPERTIES:
-    :CUSTOM_ID: h-7BF272F0
-    :END:
-
-Scour occasionally so the log directories do not fill up.
-
-#+BEGIN_SRC shell :tangle ../../../vms/thredds/thredds-install.sh
-  (crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
-#+END_SRC
 
 ** LDM Data Directory from idd-archiver Via NFS
    :PROPERTIES:

--- a/centos-init.sh
+++ b/centos-init.sh
@@ -22,4 +22,7 @@ chmod +x /usr/local/bin/docker-compose
 systemctl enable docker.service
 systemctl start docker.service
 
+mkdir /logs
+chown -R ${DOCKER_USER}:docker /logs
+
 reboot now

--- a/ubuntu-init.sh
+++ b/ubuntu-init.sh
@@ -26,4 +26,7 @@ chmod +x /usr/local/bin/docker-compose
 
 service docker start
 
+mkdir /logs
+chown -R ${DOCKER_USER}:docker /logs
+
 reboot now

--- a/vm-init-readme.md
+++ b/vm-init-readme.md
@@ -5,6 +5,7 @@
     - [Install Docker](#h-786799C4)
     - [Install docker-compose](#h-02EF6BAD)
     - [Start Docker Daemon](#h-B6F088A3)
+    - [Logging](#h-E37376D1)
     - [Reboot](#h-6D94F8D5)
     - [Docker Hello World](#h-F3633FE6)
   - [Other Environments (e.g., macOS, Windows)](#h-D1009153)
@@ -113,6 +114,18 @@ or
 ```shell
 systemctl enable docker.service
 systemctl start docker.service
+```
+
+
+<a id="h-E37376D1"></a>
+
+### Logging
+
+Set up standard logging directory:
+
+```shell
+mkdir /logs
+chown -R ${DOCKER_USER}:docker /logs
 ```
 
 

--- a/vms/idd-archiver/docker-compose.yml
+++ b/vms/idd-archiver/docker-compose.yml
@@ -35,6 +35,6 @@ services:
     volumes:
         - /data/:/data/
         - ~/tdsconfig/:/usr/local/tomcat/content/thredds/
-        - ~/logs/tdm/:/usr/local/tomcat/content/tdm/
+        - /logs/tdm/:/usr/local/tomcat/content/tdm/
     env_file:
         - "compose.env"

--- a/vms/idd-archiver/readme.md
+++ b/vms/idd-archiver/readme.md
@@ -245,20 +245,20 @@ While not related to IDD archival, the [TDM](https://www.unidata.ucar.edu/softwa
 Create a logging directory for the TDM:
 
 ```shell
-mkdir -p ~/logs/tdm
+mkdir -p /logs/tdm
 ```
 
 1.  Running the TDM Out the TDM Log Directory
 
-    [TDM logging will not be configurable until TDS 5.0](https://github.com/Unidata/tdm-docker#capturing-tdm-log-files-outside-the-container). Until then we are running the TDM out of the `~/logs/tdm` directory:
+    [TDM logging will not be configurable until TDS 5.0](https://github.com/Unidata/tdm-docker#capturing-tdm-log-files-outside-the-container). Until then we are running the TDM out of the `/logs/tdm` directory:
 
     ```shell
     curl -SL  \
          https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/edu/ucar/tdmFat/4.6.13/tdmFat-4.6.13.jar \
-         -o ~/logs/tdm/tdm.jar
+         -o /logs/tdm/tdm.jar
     curl -SL https://raw.githubusercontent.com/Unidata/tdm-docker/master/tdm.sh \
-         -o ~/logs/tdm/tdm.sh
-    chmod +x  ~/logs/tdm/tdm.sh
+         -o /logs/tdm/tdm.sh
+    chmod +x  /logs/tdm/tdm.sh
     ```
 
 
@@ -385,7 +385,7 @@ services:
     volumes:
         - /data/:/data/
         - ~/tdsconfig/:/usr/local/tomcat/content/thredds/
-        - ~/logs/tdm/:/usr/local/tomcat/content/tdm/
+        - /logs/tdm/:/usr/local/tomcat/content/tdm/
     env_file:
         - "compose.env"
 ```

--- a/vms/idd-relay/readme.md
+++ b/vms/idd-relay/readme.md
@@ -4,7 +4,7 @@
   - [Start IDD Relay With Docker and docker-compose](#h-C89E3FF5)
   - [~/etc Directory](#h-E4AB4451)
   - [~/queues Directory](#h-F3D77CEF)
-  - [~/logs Directory](#h-515DAD84)
+  - [/logs Directory](#h-515DAD84)
   - [Port 388](#h-FB14DD93)
   - [docker-compose.yml](#h-95441A93)
     - [LDM Environment Variable Parameterization](#h-031CD94A)
@@ -69,12 +69,12 @@ mkdir -p ~/queues
 
 <a id="h-515DAD84"></a>
 
-## ~/logs Directory
+## /logs Directory
 
 Create the LDM `logs` directory.
 
 ```shell
-mkdir -p ~/logs/ldm
+mkdir -p /logs/ldm
 ```
 
 

--- a/vms/ramadda/docker-compose.yml
+++ b/vms/ramadda/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     volumes:
       - /repository/:/data/repository/
       - /data/ldm/:/data/ldm/
-      - ~/logs/ramadda-tomcat/:/usr/local/tomcat/logs/
-      - ~/logs/ramadda/:/data/repository/logs/
+      - /logs/ramadda-tomcat/:/usr/local/tomcat/logs/
+      - /logs/ramadda/:/data/repository/logs/
       - ./files/index.jsp:/usr/local/tomcat/webapps/ROOT/index.jsp
       # Everything below is required for https
       - ./files/server.xml:/usr/local/tomcat/conf/server.xml

--- a/vms/ramadda/ramadda-install.sh
+++ b/vms/ramadda/ramadda-install.sh
@@ -4,7 +4,5 @@
 echo ramadda.install.password=changeme! | tee --append \
   /repository/pw.properties > /dev/null
 
-mkdir -p ~/logs/ramadda-tomcat/
-mkdir -p ~/logs/ramadda/
-
-(crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
+mkdir -p /logs/ramadda-tomcat/
+mkdir -p /logs/ramadda/

--- a/vms/ramadda/readme.md
+++ b/vms/ramadda/readme.md
@@ -6,7 +6,6 @@
   - [Create RAMADDA default password](#h-D5095E2A)
   - [RAMADDA log Directories](#h-1C3FF741)
     - [Create log Directories](#h-DABCF6E2)
-    - [Scour log Directories](#h-1121D213)
   - [LDM Data Directory from idd-archiver Via NFS](#h-85431E50)
   - [HTTPS and SSL Certificate](#h-44DE4A34)
     - [Certificate from CA](#h-5B0B20B7)
@@ -88,19 +87,8 @@ echo ramadda.install.password=changeme! | tee --append \
 You will need an Apache Tomcat and RAMADDA log directories:
 
 ```shell
-mkdir -p ~/logs/ramadda-tomcat/
-mkdir -p ~/logs/ramadda/
-```
-
-
-<a id="h-1121D213"></a>
-
-### Scour log Directories
-
-Scour occasionally so the log directories do not fill up.
-
-```shell
-(crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
+mkdir -p /logs/ramadda-tomcat/
+mkdir -p /logs/ramadda/
 ```
 
 
@@ -180,8 +168,8 @@ services:
     volumes:
       - /repository/:/data/repository/
       - /data/ldm/:/data/ldm/
-      - ~/logs/ramadda-tomcat/:/usr/local/tomcat/logs/
-      - ~/logs/ramadda/:/data/repository/logs/
+      - /logs/ramadda-tomcat/:/usr/local/tomcat/logs/
+      - /logs/ramadda/:/data/repository/logs/
       - ./files/index.jsp:/usr/local/tomcat/webapps/ROOT/index.jsp
       # Everything below is required for https
       - ./files/server.xml:/usr/local/tomcat/conf/server.xml

--- a/vms/science-gateway/docker-compose.yml
+++ b/vms/science-gateway/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./web/:/usr/share/nginx/html:ro
-      - ~/logs/nginx/:/var/log/nginx/
+      - /logs/nginx/:/var/log/nginx/
       - /etc/ssl/science-gateway/science-gateway.unidata.ucar.edu.crt:/etc/nginx/science-gateway.unidata.ucar.edu.crt
       - /etc/ssl/science-gateway/science-gateway.unidata.ucar.edu.key:/etc/nginx/science-gateway.unidata.ucar.edu.key
       - /etc/ssl/science-gateway/ca-certs.pem:/etc/nginx/ca-certs.pem

--- a/vms/science-gateway/readme.md
+++ b/vms/science-gateway/readme.md
@@ -57,10 +57,10 @@ With the help of Docker and `docker-compose`, starting a VM containing an IDD ar
 
 ## Logging
 
-The nginx log directory:
+Create the following nginx log directory:
 
 ```shell
-mkdir -p ~/logs/nginx/
+mkdir -p /logs/nginx
 ```
 
 

--- a/vms/thredds-aws/docker-compose.yml
+++ b/vms/thredds-aws/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - "443:8443"
       - "8443:8443"
     volumes:
-      - ~/logs/tds-tomcat/:/usr/local/tomcat/logs/
-      - ~/logs/tds/:/usr/local/tomcat/content/thredds/logs/
+      - /logs/tds-tomcat/:/usr/local/tomcat/logs/
+      - /logs/tds/:/usr/local/tomcat/content/thredds/logs/
       # ssl certs, keys not in version control, see readme.md
       - ./files/ssl.crt:/usr/local/tomcat/conf/ssl.crt
       - ./files/ssl.key:/usr/local/tomcat/conf/ssl.key

--- a/vms/thredds-aws/readme.md
+++ b/vms/thredds-aws/readme.md
@@ -7,7 +7,6 @@
     - [Supply Contact and Host Information in threddsConfig.xml](#h-615B0684)
   - [TDS log Directories](#h-F52D01A2)
     - [Create log Directories](#h-99E9AD76)
-    - [Scour log Directories](#h-AC0813AF)
   - [S3Objects Directory](#h-F6EBEBDF)
     - [Create S3Objects Directory](#h-763C22DA)
     - [Scour S3Objects Directory](#h-483C35F9)
@@ -103,19 +102,8 @@ Edit the `~/tdsconfig/threddsConfig.xml` to supply contact and host institution 
 You will need Apache Tomcat and TDS log directories:
 
 ```shell
-mkdir -p ~/logs/tds-tomcat/
-mkdir -p ~/logs/tds/
-```
-
-
-<a id="h-AC0813AF"></a>
-
-### Scour log Directories
-
-Scour occasionally so the log directories do not fill up.
-
-```shell
-(crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
+mkdir -p /logs/tds-tomcat/
+mkdir -p /logs/tds/
 ```
 
 
@@ -187,8 +175,8 @@ services:
       - "443:8443"
       - "8443:8443"
     volumes:
-      - ~/logs/tds-tomcat/:/usr/local/tomcat/logs/
-      - ~/logs/tds/:/usr/local/tomcat/content/thredds/logs/
+      - /logs/tds-tomcat/:/usr/local/tomcat/logs/
+      - /logs/tds/:/usr/local/tomcat/content/thredds/logs/
       # ssl certs, keys not in version control, see readme.md
       - ./files/ssl.crt:/usr/local/tomcat/conf/ssl.crt
       - ./files/ssl.key:/usr/local/tomcat/conf/ssl.key

--- a/vms/thredds-aws/thredds-aws-install.sh
+++ b/vms/thredds-aws/thredds-aws-install.sh
@@ -2,10 +2,8 @@ mkdir -p ~/tdsconfig/
 wget http://unidata-tds.s3.amazonaws.com/tdsConfig/awsL2/config.zip -O ~/tdsconfig/config.zip
 unzip ~/tdsconfig/config.zip -d ~/tdsconfig/
 
-mkdir -p ~/logs/tds-tomcat/
-mkdir -p ~/logs/tds/
-
-(crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
+mkdir -p /logs/tds-tomcat/
+mkdir -p /logs/tds/
 
 mkdir -p ~/S3Objects
 

--- a/vms/thredds-test/docker-compose.yml
+++ b/vms/thredds-test/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     volumes:
         - /data/:/data/
         - ~/tdsconfig/:/usr/local/tomcat/content/thredds/
-        - ~/logs/tdm/:/usr/local/tomcat/content/tdm/
+        - /logs/tdm/:/usr/local/tomcat/content/tdm/
     env_file:
         - "compose${THREDDS_COMPOSE_ENV_LOCAL}.env"
 
@@ -50,8 +50,8 @@ services:
       - "443:8443"
       - "8443:8443"
     volumes:
-      - ~/logs/tds-tomcat/:/usr/local/tomcat/logs/
-      - ~/logs/tds/:/usr/local/tomcat/content/thredds/logs/
+      - /logs/tds-tomcat/:/usr/local/tomcat/logs/
+      - /logs/tds/:/usr/local/tomcat/content/thredds/logs/
       # ssl certs, keys not in version control, see readme.md
       - ../thredds/files/ssl.crt:/usr/local/tomcat/conf/ssl.crt
       - ../thredds/files/ssl.key:/usr/local/tomcat/conf/ssl.key

--- a/vms/thredds/docker-compose.yml
+++ b/vms/thredds/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - "443:8443"
       - "8443:8443"
     volumes:
-      - ~/logs/tds-tomcat/:/usr/local/tomcat/logs/
-      - ~/logs/tds/:/usr/local/tomcat/content/thredds/logs/
+      - /logs/tds-tomcat/:/usr/local/tomcat/logs/
+      - /logs/tds/:/usr/local/tomcat/content/thredds/logs/
       - ./files/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
       - ./files/tdsCat.css:/usr/local/tomcat/webapps/thredds/tdsCat.css
       - ./files/folder.gif:/usr/local/tomcat/webapps/thredds/folder.gif

--- a/vms/thredds/readme.md
+++ b/vms/thredds/readme.md
@@ -6,7 +6,6 @@
     - [Supply Contact and Host Information in threddsConfig.xml](#h-3F46F49F)
   - [TDS log Directories](#h-E0771AED)
     - [Create log Directories](#h-F83FDEE6)
-    - [Scour log Directories](#h-7BF272F0)
   - [LDM Data Directory from idd-archiver Via NFS](#h-F043AB6A)
     - [Ensure /data Availability Upon Machine Restart](#h-437D2B38)
   - [HTTPS and SSL Certificate](#h-C5008DD9)
@@ -93,19 +92,8 @@ Edit the `~/tdsconfig/threddsConfig.xml` to supply contact and host institution 
 You will need Apache Tomcat and TDS log directories:
 
 ```shell
-mkdir -p ~/logs/tds-tomcat/
-mkdir -p ~/logs/tds/
-```
-
-
-<a id="h-7BF272F0"></a>
-
-### Scour log Directories
-
-Scour occasionally so the log directories do not fill up.
-
-```shell
-(crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
+mkdir -p /logs/tds-tomcat/
+mkdir -p /logs/tds/
 ```
 
 
@@ -197,8 +185,8 @@ services:
       - "443:8443"
       - "8443:8443"
     volumes:
-      - ~/logs/tds-tomcat/:/usr/local/tomcat/logs/
-      - ~/logs/tds/:/usr/local/tomcat/content/thredds/logs/
+      - /logs/tds-tomcat/:/usr/local/tomcat/logs/
+      - /logs/tds/:/usr/local/tomcat/content/thredds/logs/
       - ./files/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
       - ./files/tdsCat.css:/usr/local/tomcat/webapps/thredds/tdsCat.css
       - ./files/folder.gif:/usr/local/tomcat/webapps/thredds/folder.gif

--- a/vms/thredds/thredds-install.sh
+++ b/vms/thredds/thredds-install.sh
@@ -2,10 +2,8 @@ mkdir -p ~/tdsconfig/
 wget http://unidata-tds.s3.amazonaws.com/tdsConfig/newThredds/config.zip -O ~/tdsconfig/config.zip
 unzip ~/tdsconfig/config.zip -d ~/tdsconfig/
 
-mkdir -p ~/logs/tds-tomcat/
-mkdir -p ~/logs/tds/
-
-(crontab -l ; echo "59 0 * * * find ~/logs -regex '.*\.\(log\|txt\)' -type f -mtime +10 -exec rm -f {} \;")| crontab -
+mkdir -p /logs/tds-tomcat/
+mkdir -p /logs/tds/
 
 openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj \
   "/C=US/ST=Colorado/L=Boulder/O=Unidata/CN=jetstream.unidata.ucar.edu" \


### PR DESCRIPTION
Make logging uniform across all Gateway services (e.g., tds, tomcat, nginx) with a standard logging location (e.g., `/logs`) and implement log rotation scheme with `logrotate`.

ping @oxelson @m1schmidt 