### PR TITLE
Rocky init

### DIFF
--- a/openstack/bin/boot.sh
+++ b/openstack/bin/boot.sh
@@ -2,13 +2,15 @@
 
 usage="$(basename "$0") [-h] [-n, --name vm name] [-k, --key key name] \n
     [-s, --size vm size] [-i, --image image UID] [-ip, --ip ip address] \n
+	[-c, --security /path/to/security/script ] \n
     -- script to create VMs:\n
     -h  show this help text\n
     -n, --name vm name\n
     -k, --key key name\n
     -s, --size vm size\n
     -i, --image image UID\n
-    -ip, --ip vm ip number\n"
+    -ip, --ip vm ip number\n
+	-c, --security /path/to/security/script (defaults to \$HOME/security/security.sh)"
 
 while [[ $# > 0 ]]
 do
@@ -32,6 +34,10 @@ do
             ;;
         -ip|--ip)
             IP="$2"
+            shift # past argument
+            ;;
+		-c|--security)
+			SECURITY="$2"
             shift # past argument
             ;;
         -h|--help)
@@ -64,6 +70,12 @@ if [ -z "$VM_SIZE" ];
       exit 1
 fi
 
+if [ !(-v SECURITY ) ];
+then
+	echo "Security script not specifed, defaulting to $HOME/security/security.sh"
+	SECURITY="$HOME/security/security.sh"
+fi
+
 if [ -z "$IMAGE_NAME" ];
 then
       # Grab an RockyLinux Featured Image
@@ -81,6 +93,7 @@ openstack server create ${VM_NAME} \
   --key-name ${KEY_NAME} \
   --security-group global-ssh-22 \
   --nic net-id=${NETWORK_ID}
+  --user-data ${SECURITY}
 
 # give chance for VM to fire up
 echo sleep 30 for seconds while VM fires up

--- a/rocky-init.sh
+++ b/rocky-init.sh
@@ -1,8 +1,31 @@
 #!/bin/bash
-if [[ "$#" -ne 1 || "$EUID" -ne 0 ]]; then
-  echo "Usage: sudo ./rocky-init.sh \$USER"
+
+usage="
+Usage: sudo ./rocky-init.sh [-d, --docker-user \$USER ] [ -n, --nfs ]\n
+Include --docker and/or --nfs flags to optionally install docker/docker-compose\n
+and/or docker compose"
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Error: Must run as root"
+  echo -e $usage
   exit 1
 fi
+
+while [[ $# > 0 ]]
+do
+    key="$1"
+    case $key in
+        -d|--docker-user)
+            DOCKER_USER="$2"
+            shift # past argument
+            ;;
+        -n|--nfs)
+            INSTALL_NFS=1
+			# Shift only once at the end of this loop iteration
+            ;;
+    esac
+    shift # past argument or value
+done
 
 # When running as root (using sudo), $(id -u -n) evaluates to "root" instead of
 # the user we want to be added to the "docker" group
@@ -25,41 +48,48 @@ yum -y upgrade && yum install -y epel-release
 # Desired packages for basic use
 yum install -y sudo man man-pages vim nano git wget unzip ncurses procps htop \
 	python3 telnet openssh openssh-clients openssl findutils \
-	nfs-kernel-server nfs-common tmux
+	tmux
 
-# TODO nfs-kernel-server and nfs-common not found when running from within rockylinux container
-# Check whether this is the case in js2 rocky vms
+# NFS install
+if [ -v INSTALL_NFS ];
+then
+	echo "NFS flag supplied: Installing NFS..."
+	yum install -y nfs-kernel-server nfs-common
+fi
 
 ###
 # docker installation
 ###
+if [ -z "$DOCKER_USER" ];
+then
+	echo "Docker user flag supplied: Installing docker and docker-compose..."
+	# Convenience script doesn't support rocky, but we can still install everything manually
+	# from the centOS repo
+	# curl -sSL get.docker.com | sh
+	yum install -y yum-utils
+	yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+	yum install -y docker-ce docker-ce-cli containerd.io
 
-# Convenience script doesn't support rocky, but we can still install everything manually
-# from the centOS repo
-# curl -sSL get.docker.com | sh
-yum install -y yum-utils
-yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-yum install -y docker-ce docker-ce-cli containerd.io
+	groupadd docker
+	usermod -aG docker ${DOCKER_USER}
 
-groupadd docker
-usermod -aG docker ${DOCKER_USER}
+	# Install docker-compose (v2 acts as a plugin to the docker CLI)
+	DOCKER_CONFIG=${DOCKER_CONFIG:-/home/$DOCKER_USER/.docker}
+	mkdir -p $DOCKER_CONFIG/cli-plugins
+	curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
 
-# Install docker-compose (v2 acts as a plugin to the docker CLI)
-DOCKER_CONFIG=${DOCKER_CONFIG:-/home/$1/.docker}
-mkdir -p $DOCKER_CONFIG/cli-plugins
-curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+	# Make $USER the owner of the created directory, and make the plugin executable
+	chown -R $DOCKER_USER:$DOCKER_USER $DOCKER_CONFIG
+	chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 
-# Make $USER the owner of the created directory, and make the plugin executable
-chown -R $1:$1 $DOCKER_CONFIG
-chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+	# Only necessary for docker-compose v1
+	# chmod +x /usr/local/bin/docker-compose
 
-# Only necessary for docker-compose v1
-# chmod +x /usr/local/bin/docker-compose
+	systemctl enable docker.service
+	systemctl start docker.service
 
-systemctl enable docker.service
-systemctl start docker.service
-
-mkdir /logs
-chown -R ${DOCKER_USER}:docker /logs
+	mkdir /logs
+	chown -R ${DOCKER_USER}:docker /logs
+fi
 
 reboot now

--- a/vm-init-readme.md
+++ b/vm-init-readme.md
@@ -2,8 +2,10 @@
   - [Linux VM or Bare Metal Linux](#h-FF95E7EC)
     - [Quick Start](#h-4A4B1084)
     - [System Maintenance](#h-AE788331)
-    - [Install Docker](#h-786799C4)
+    - [Install Docker (Ubuntu)](#h-786799C4)
+    - [Install Docker (Rocky)](#rocky-docker)
     - [Install docker-compose](#h-02EF6BAD)
+    - [Create the docker Group](#docker-group)
     - [Start Docker Daemon](#h-B6F088A3)
     - [Logging](#h-E37376D1)
     - [Reboot](#h-6D94F8D5)
@@ -16,31 +18,44 @@
 
 # Virtual Machine Initialization
 
-The `science-gateway` project is heavily dependent on Docker, and you will have to have access to a recent version of Docker. Herein are some instructions to help you get going with Docker and other system maintenance you will need to perform.
+The `science-gateway` project is heavily dependent on Docker, and you will have
+to have access to a recent version of Docker. Herein are some instructions to
+help you get going with Docker and other system maintenance you will need to
+perform. The commands laid out by these instructions are contained in the
+convenience scripts `rocky-init.sh` and `ubuntu-init.sh`. However, only
+`rocky-init.sh` is being actively maintained as RockyLinux has become the OS of
+choice for JetStream2 VMs.
 
 
 <a id="h-FF95E7EC"></a>
 
 ## Linux VM or Bare Metal Linux
 
-
 <a id="h-4A4B1084"></a>
 
 ### Quick Start
 
-Quick start instructions for Linux OS can be found here. For a more complete explanation of the Docker installation start with the [System Maintenance](#h-AE788331) section.
+Quick start instructions for Linux OS can be found here. For a more complete
+explanation of the Docker installation start with the [System
+Maintenance](#h-AE788331) section. Clone the science-gateway repository:
 
 ```shell
 git clone https://github.com/Unidata/science-gateway
 ```
 
-and run the `ubuntu-init.sh` or `centos-init.sh` script co-located with this readme, e.g.,:
+and run the `ubuntu-init.sh` or `rocky-init.sh` as root, script co-located with
+this readme. Many of the commands found below (and within those scripts) require
+root privileges. As always, ensure you know what you're doing before running
+anything as root:
 
 ```shell
 cd science-gateway
-sudo ./<linux-distro>-init.sh -u ${USER}
+sudo ./<linux-distro>-init.sh
 ```
 
+Optionally, include the `-d or --docker` flag with the appropriate argument (see
+[Install Docker (Rocky)](#rocky-docker)) if `docker` will be ran on the VM, and
+the `-n or --nfs` flag if the VM will act as a NFS server.
 
 <a id="h-AE788331"></a>
 
@@ -48,7 +63,10 @@ sudo ./<linux-distro>-init.sh -u ${USER}
 
 Always think before typing the following commands as `root` user!
 
-Do the usual maintenance via `apt-get` or `yum`. Also install a few ancillary packages (e.g., `git`, etc.) for good measure. Purge Docker from the system before installing fresh Docker.
+Do the usual maintenance via `apt-get` or `yum`. Also install a few ancillary
+packages and repositories (e.g., `git`, etc.) for good measure. Purge Docker and
+any other packages from the system that may conflict with a fresh Docker
+installation.
 
 1.  apt-get
 
@@ -70,34 +88,85 @@ Do the usual maintenance via `apt-get` or `yum`. Also install a few ancillary pa
     ```shell
     systemctl stop docker
 
-    yum -y remove docker docker-common docker-selinux docker-engine-selinux \
-      docker-engine docker-ce && rm -rf /var/lib/docker && yum -y update && yum -y \
-      install git unzip wget nfs-kernel-server nfs-common
+	# Remove any existing packages that may conflict with the installation
+	yum -y remove docker docker-common docker-selinux docker-engine-selinux \
+	  docker-engine docker-ce podman buildah && rm -rf /var/lib/docker
+
+	# Upgrade existing packages and install the Extra Packages for Enterprise Linux repo
+	yum -y upgrade && yum install -y epel-release
+
+	# Desired packages for basic use
+	yum install -y sudo man man-pages vim nano git wget unzip ncurses procps htop \
+		python3 telnet openssh openssh-clients openssl findutils \
+		tmux
     ```
 
 
 <a id="h-786799C4"></a>
 
-### Install Docker
+### Install Docker (Ubuntu)
 
-Define a `DOCKER_USER`. Again, think before you type.
+On Ubuntu, you can install docker using a convencience script provided by the
+docker folks:
+
 
 ```shell
+# To inspect the script before running anything, pipe the output of the curl
+# command into your favorite text viewer, such as less or vim
+curl -sSL get.docker.com | less
+
+# Run the script
 curl -sSL get.docker.com | sh
-usermod -aG docker ${DOCKER_USER}
 ```
 
+<a id="rocky-docker"></a>
+
+### Install Docker (Rocky)
+
+The convenience script used to install docker on Ubuntu does not have RockyLinux
+support, however, we can still manually install everything from the centOS
+repository.
+
+```shell
+yum install -y yum-utils
+yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+yum install -y docker-ce docker-ce-cli containerd.io
+```
 
 <a id="h-02EF6BAD"></a>
 
 ### Install docker-compose
 
-```shell
-curl -L https://github.com/docker/compose/releases/download/1.26.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+Docker compose is a tool for running multi-container docker applications through
+a `docker-compose.yml` configuration file, but is also useful for defining how
+single container applications should be ran by specifiying parameters such as
+volume mounts and environment variables.
 
-chmod +x /usr/local/bin/docker-compose
+The most recent version of docker compose, acts as a plugin to docker:
+
+```shell
+# Install docker-compose (v2 acts as a plugin to the docker CLI)
+DOCKER_CONFIG=${DOCKER_CONFIG:-/home/$DOCKER_USER/.docker}
+mkdir -p $DOCKER_CONFIG/cli-plugins
+curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+
+# Make $USER the owner of the created directory, and make the plugin executable
+chown -R $DOCKER_USER:$DOCKER_USER $DOCKER_CONFIG
+chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 ```
 
+<a id="docker-group"></a>
+
+### Create the docker Group
+
+Create a `docker` group and add the supplied `DOCKER_USER` to this group. This
+allows `$DOCKER_USER` to run docker commands without root privileges. Again,
+think before you type.
+
+```shell
+group add docker
+usermod -aG docker ${DOCKER_USER}
+```
 
 <a id="h-B6F088A3"></a>
 
@@ -106,16 +175,17 @@ chmod +x /usr/local/bin/docker-compose
 As `root` user, make sure Docker is available as a daemon. You can issue one of the following commands depending on your flavor of Linux.
 
 ```shell
+# Ubuntu
 service docker start
 ```
 
 or
 
 ```shell
+# Rocky
 systemctl enable docker.service
 systemctl start docker.service
 ```
-
 
 <a id="h-E37376D1"></a>
 
@@ -150,8 +220,9 @@ Run this container to make sure the docker install has gone smoothly:
 
 ```shell
 docker run hello-world
+docker compose --help
+docker-compose --help
 ```
-
 
 <a id="h-D1009153"></a>
 


### PR DESCRIPTION
Update rocky-init and boot.sh, as well as the corresponding documentation.

@julienchastang as per @m1schmidt 's request, docker and NFS are now explicitly installed through command line arguments passed to rocky-init.sh

boot.sh now passes a security script (found only on JS2, not in this repo) to newly created VMs that applies our security profile on first boot