### PR TITLE
Pull from non-"minimal" images; Work on 1 branch

### DIFF
--- a/.github/helperScripts/updateBuildPush.sh
+++ b/.github/helperScripts/updateBuildPush.sh
@@ -45,8 +45,10 @@ if [[ -z "$UPSTREAM" || -z "$IMAGENAME" || -z "$REGISTRYPWD" || -z "$REGISTRYUSE
 	exit 1
 fi
 
-BRANCHES=$(git branch -r --list "origin/*" | grep -v -e "HEAD" | awk -F "/" '{ print $2 }' | xargs)
-BRANCHES=( $BRANCHES )
+# Operate only on a single branch
+# BRANCHES=$(git branch -r --list "origin/*" | grep -v -e "HEAD" | awk -F "/" '{ print $2 }' | xargs)
+# BRANCHES=( $BRANCHES )
+BRANCHES=("master")
 
 ROCKYPATH="./openstack/rocky"
 

--- a/.github/workflows/update-rocky.yml
+++ b/.github/workflows/update-rocky.yml
@@ -40,8 +40,8 @@ jobs:
 
     - name: Grab the most recent upstream version
       run: |
-        echo $(${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v "latest" | sort -Vr)
-        upstream=$( ${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v "latest" | sort -Vr | head -n1 )
+        echo $(${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v -e "latest" -e "minimal" | sort -Vr)
+        upstream=$( ${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v -e "latest" -e "minimal" | sort -Vr | head -n1 )
         echo $upstream
         echo "upstream=$upstream" >> $GITHUB_ENV
 


### PR DESCRIPTION
RockyLinux pushed new "minimal" images to dockerhub which are truly
minimal--they don't even have a package manager such as yum or dnf. The
grep command used to parse the different RockyLinux tags from dockerhub
is updated to exclude any tags that have "minimal" in their names.

The updateBuildPush.sh script was written to operate on all branches of
a repo, but this could cause issues such as merge conflicts between
different branches within the repo or from a fork that has an
open/un-merged PR. Change this script to operate on a single branch.