### PR TITLE
Issue #683

### DIFF
--- a/openstack/openstack.sh
+++ b/openstack/openstack.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-usage="$(basename "$0") [-h] [-o, --openrc openrc.sh file path] \n
+usage="$(basename "$0") [-h] [-o, --openrc openrc.sh file path] [-n, --name <container-name>\n
 -- script to  start OpenStack CL Docker container. \n Arguments must be supplied with fully qualified paths.\n
     -h  show this help text\n
-    -o, --openrc full path to directory with openrc.sh file obtained from Jetstream (bin)\n"
+    -o, --openrc full path to directory with openrc.sh file obtained from Jetstream (bin)\n
+    -n, --name container-name"
 
 while [[ $# > 0 ]]
 do
@@ -11,6 +12,10 @@ do
     case $key in
         -o|--openrc)
             OPENRC="$2"
+            shift # past argument
+            ;;
+        -n|--name)
+            NAME="$2"
             shift # past argument
             ;;
         -h|--help)
@@ -28,9 +33,17 @@ if [ -z "$OPENRC" ];
       exit 1
 fi
 
-docker run -it  \
+if [ -z "$NAME" ];
+   then
+      echo "Must supply a name for the new docker container:"
+      echo -e $usage
+      exit 1
+fi
+
+docker run --name $NAME -it  \
        -v ${PWD}/bin:/home/openstack/bin/ \
        -v ${PWD}/.bashrc:/home/openstack/.bashrc \
        -v ${OPENRC}:/home/openstack/bin/openrc.sh \
+       -v ${HOME}/security:/home/openstack/security \
        unidata/science-gateway /bin/bash
 


### PR DESCRIPTION
Make security directory (found only on a JS2 machine) available to
unidata/science-gateway containers through a volume mount when firing
them up through openstack.sh

While we're at it give a name argument to the script to name the newly
created container.