### PR TITLE
Remove "rocky" user from image

### DIFF
--- a/openstack/Dockerfile
+++ b/openstack/Dockerfile
@@ -1,7 +1,5 @@
 FROM unidata/rockylinux:latest-8
 
-USER root
-
 ###
 # Kubectl
 ###

--- a/openstack/rocky/Dockerfile
+++ b/openstack/rocky/Dockerfile
@@ -11,15 +11,4 @@ RUN yum upgrade -y && yum install -y epel-release
 RUN yum install -y sudo man man-pages vim nano git wget unzip ncurses procps \
 	htop python3 telnet openssh openssh-clients openssl findutils diffutils
 
-###
-# Create rocky user account and add to sudoers file
-###
-
-RUN useradd -ms /bin/bash rocky
-ENV HOME /home/rocky
-ENV USER rocky
-RUN echo "rocky ALL=NOPASSWD: ALL" >> /etc/sudoers
-WORKDIR $HOME
-USER rocky
-
 CMD echo 'Build successful! For interactive mode, run as "docker run -it unidata/rocky /bin/bash"'

--- a/openstack/rocky/Dockerfile.latest-8
+++ b/openstack/rocky/Dockerfile.latest-8
@@ -12,15 +12,4 @@ RUN yum upgrade -y && yum install -y epel-release
 RUN yum install -y sudo man man-pages vim nano git wget unzip ncurses procps \
 	htop python3 telnet openssh openssh-clients openssl findutils diffutils
 
-###
-# Create rocky user account and add to sudoers file
-###
-
-RUN useradd -ms /bin/bash rocky
-ENV HOME /home/rocky
-ENV USER rocky
-RUN echo "rocky ALL=NOPASSWD: ALL" >> /etc/sudoers
-WORKDIR $HOME
-USER rocky
-
 CMD echo 'Build successful! For interactive mode, run as "docker run -it unidata/rocky /bin/bash"'


### PR DESCRIPTION
Images based on unidata/rockylinux may have requirements for user/group
IDs that conflict with the "rocky" user from the base image. Remove the
rocky user from the base image and allow downstream images to manage
their own users.

Resolves issue #682, which was ultimately caused by this mulit-user
container.