### PR TITLE
Updates

### DIFF
--- a/.github/workflows/science-gateway.yml
+++ b/.github/workflows/science-gateway.yml
@@ -1,0 +1,43 @@
+################################################
+# NECESSARY GITHUB SECRETS TO SET              #
+################################################
+# secrets.registryuser
+# secrets.registrypwd
+# secrets.server : (not currently implemented)
+################################################
+
+name: "Build/Push Science Gateway"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  buildAndPush:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set environment variables
+        run: |
+          echo "Image tag set to: $(date +%Y%m%d)"
+          echo "tag=$(date +%Y%m%d)" >> $GITHUB_ENV
+          echo "imagename=unidata/science-gateway" >> $GITHUB_ENV
+
+      # Checkout the commit that triggered the workflow
+      - uses: actions/checkout@v2
+
+      - name: Check environment
+        run: "echo ${{ env.imagename }}:${{ env.tag }}"
+
+      - name: Build the Docker image
+        run: |
+          cd openstack;
+          docker build --no-cache --tag ${{ env.imagename }}:${{ env.tag }} .;
+          docker tag ${{ env.imagename }}:${{ env.tag }} ${{ env.imagename }}:latest
+
+      - name: Push the Docker image
+        run: |
+          docker logout;
+          echo ${{ secrets.registrypwd }} | docker login -u ${{ secrets.registryuser }} --password-stdin
+          docker push ${{ env.imagename }}:${{ env.tag }} &&
+          docker push ${{ env.imagename }}:latest &&
+          { docker logout && echo "Successfully pushed ${{ env.imagename }} (tags: ${{ env.tag }}, latest)"; } ||
+          { docker logout && echo "Docker push failed" && exit 1; }

--- a/openstack/Dockerfile
+++ b/openstack/Dockerfile
@@ -59,7 +59,7 @@ RUN pip3 install --upgrade pip
 
 RUN pip3 install -r $HOME/jetstream_kubespray/requirements.txt
 
-RUN pip3 install --upgrade python-openstackclient --ignore-installed
+RUN pip3 install --upgrade python-openstackclient python-designateclient --ignore-installed
 
 RUN mkdir $HOME/.kube
 

--- a/openstack/bin/kube-setup.sh
+++ b/openstack/bin/kube-setup.sh
@@ -12,6 +12,11 @@ sed -i "s/number_of_k8s_nodes_no_floating_ip = 0/number_of_k8s_nodes_no_floating
 sed -i "s/k8s_allowed_remote_ips = \[\"0.0.0.0\/0\"\]/k8s_allowed_remote_ips =  \[\"128.117.144.0\/24\", \"149.165.152.95\"\]/g" cluster.tfvars
 sed -i "s/149.xxx.xxx.xxx/"$IP"/g" group_vars/k8s_cluster/k8s-cluster.yml
 
+# Uncomment the dns-domain property line
+sed -i "s/# network_dns_domain/network_dns_domain/g" cluster.tfvars
+# Replace project ID
+sed -i "s/<project-ID>/tg-ees220002/g" cluster.tfvars
+
 bash terraform_init.sh
 bash terraform_apply.sh
 


### PR DESCRIPTION
- Added python-designateclient to science-gateway image (provides openstack recordset commands)
- Modified kube-spray.sh to also edit the [newly merged](https://github.com/zonca/jetstream_kubespray/pull/16/commits/4def7d8b6f8f8c94d4eac3f017cfc2ba03d3c9d4) network_dns_domain property in cluster.tfvars
- Added a manually dispatched GHA workflow file to build/push our unidata/science-gateway image to dockerhub