### PR TITLE
Use DockerHub API for querying tags

### DIFF
--- a/.github/helperScripts/dockertags.sh
+++ b/.github/helperScripts/dockertags.sh
@@ -1,30 +1,99 @@
 #!/bin/bash
 
-# Shamelessly taken from StackOverflow. No need to reinvent the wheel right?
-# https://stackoverflow.com/questions/28320134/how-can-i-list-all-tags-for-a-docker-image-on-a-remote-registry
+USAGE="
+dockertags  --  list all tags for a Docker image in the DockerHub registry \n
+\n
+INPUTS: \n
+./dockertags -u|--user <user> \ \n
+    -p|--password <password> \ \n
+    -n|--namespace <namespace> \ \n
+    -i|--image <image> \ \n
+    [ -h|--help ] \n
+\n
+--user: username used for authentication to dockerhub registry \n
+--password: password or personal access token \n
+--namespace: organization name (e.g. "unidata"); "library" for public repos \n
+--image: the name of the image \n
+--help: print this help message and exit \n
+\n
+OUTPUTS: \n
+The tags of the desired image, each on a new line. For example: \n
+\n
+$ ./dockertags --user $USERNAME \ \n
+    --password $PASSWORD \ \n
+    --namespace library \ \n
+    --image $IMAGE \n
+\n
+tag1 \n
+tag2 \n
+tag3 \n
+"
 
-if [ $# -lt 1 ]
-then
-cat << HELP
+while [[ $# > 0 ]]
+do
+    key="$1"
+    case $key in
+        -u|--user)
+            USERNAME="$2"
+            shift # past argument
+            ;;
+        -p|--password)
+            PASSWORD="$2"
+            shift # past argument
+            ;;
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift # past argument
+            ;;
+        -i|--image)
+            IMAGE="$2"
+            shift # past argument
+            ;;
+        -h|--help)
+            echo -e $USAGE
+            exit
+            ;;
+    esac
+    shift # past argument or value
+done
 
-dockertags  --  list all tags for a Docker image on a remote registry.
+# Check if all values were set
+[[ -z "$USERNAME" ]] && { echo -e "Must supply a username...Exiting" $USAGE; exit 1; }
+[[ -z "$PASSWORD" ]] && { echo -e "Must supply a password...Exiting" $USAGE; exit 1; }
+[[ -z "$NAMESPACE" ]] && { echo -e "Must supply a namespace...Exiting" $USAGE; exit 1; }
+[[ -z "$IMAGE" ]] && { echo -e "Must supply an image...Exiting" $USAGE; exit 1; }
 
-EXAMPLE: 
-    - list all tags for ubuntu:
-       dockertags ubuntu
+# Grab a token for authentiting when querying the registry
+token=$(curl -Ls -X POST https://hub.docker.com/v2/users/login \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}" | jq -r .token)
 
-    - list all php tags containing apache:
-       dockertags php apache
+# Query the registry for the first 100 entries (the maximum page size)
+RESPONSE=$(curl -Ls -G \
+    --data-urlencode "page_size=100" \
+    --data-urlencode "page=1" \
+    -H "Authorization: Bearer ${token}" \
+    https://hub.docker.com/v2/namespaces/${NAMESPACE}/repositories/${IMAGE}/tags)
 
-HELP
-fi
+# Parse using jq
+TAGS=$(echo $RESPONSE | jq '.results[].name')
 
-image="$1"
-tags=`wget -q https://registry.hub.docker.com/v1/repositories/${image}/tags -O -  | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}'`
+# If more than 100 tags exist in the repository, we must loop through all pages
+# using the "next" field of the JSON response
+let PAGE=1
+NEXTURL=$(echo $RESPONSE | jq '.next')
 
-if [ -n "$2" ]
-then
-    tags=` echo "${tags}" | grep "$2" `
-fi
+while [[ "${NEXTURL}" != "null" ]];
+do
+    let PAGE+=1
+    RESPONSE=$(curl -Ls -G \
+        --data-urlencode "page_size=100" \
+        --data-urlencode "page=$PAGE" \
+        -H "Authorization: Bearer ${token}" \
+        https://hub.docker.com/v2/namespaces/${NAMESPACE}/repositories/${IMAGE}/tags)
+        TAGS+=" $(echo $RESPONSE | jq '.results[].name')"
+    NEXTURL=$(echo $RESPONSE | jq '.next')
+done
 
-echo "${tags}"
+# Print each tag on its own line and remove quotes (") from around each tag
+printf '%s\n' $TAGS | sed -e 's/"//g'

--- a/.github/workflows/update-rocky.yml
+++ b/.github/workflows/update-rocky.yml
@@ -40,18 +40,30 @@ jobs:
 
     - name: Grab the most recent upstream version
       run: |
-        echo $(${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v -e "latest" -e "minimal" | sort -Vr)
-        upstream=$( ${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v -e "latest" -e "minimal" | sort -Vr | head -n1 )
+        upstream=$(${{ env.scriptsdir }}/dockertags.sh \
+        --user ${{ secrets.registryuser }} \
+        --password ${{ secrets.registrypwd }} \
+        --namespace library \
+        --image rockylinux \
+        | grep -v -e "latest" -e "minimal" \
+        | sort -Vr \
+        | head -n1)
         echo $upstream
         echo "upstream=$upstream" >> $GITHUB_ENV
 
     - name: Grab the most recent upstream 8.x version
       run: |
-        echo $(${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v -e "latest" -e "minimal" | sort -Vr)
-        upstream8=$( ${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -e "^8" | grep -v -e "latest" -e "minimal" | sort -Vr | head -n1 )
+        upstream8=$(${{ env.scriptsdir }}/dockertags.sh \
+        --user ${{ secrets.registryuser }} \
+        --password ${{ secrets.registrypwd }} \
+        --namespace library \
+        --image rockylinux \
+        | grep -e "^8" \
+        | grep -v -e "latest" -e "minimal" \
+        | sort -Vr \
+        | head -n1)
         echo $upstream8
         echo "upstream8=$upstream8" >> $GITHUB_ENV
-
 
     - name: Check, update, build, push
       run: |


### PR DESCRIPTION
The docker registry API (v1) that was in use is now deprecated, so we use the new DockerHub API