### PR TITLE
Base on jupyter/scipy-notebook

### DIFF
--- a/jupyter-images/shared/Dockerfile
+++ b/jupyter-images/shared/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/jupyter/docker-stacks/blob/main/scipy-notebook/Dockerfile
 
 # https://discourse.jupyter.org/t/keyerror-missing-required-environment-jupyterhub-service-url/19096
-ARG BASE_CONTAINER=jupyter/minimal-notebook
+ARG BASE_CONTAINER=jupyter/scipy-notebook
 FROM $BASE_CONTAINER
 
 ENV DEFAULT_ENV_NAME=unidata-standard


### PR DESCRIPTION
@julienchastang 

Suggested change to base our images on [jupyter/scipy-notebook](https://github.com/jupyter/docker-stacks/blob/main/images/scipy-notebook/Dockerfile) as opposed to the [jupyter/minimal-notebook](https://github.com/jupyter/docker-stacks/blob/main/images/minimal-notebook/Dockerfile)

At some point I had changed this to the minimal-notebook, which was a decision intended to reduce image size by only including those packages that we explicitly asked for. This was especially important when doing things that involved the installation of large additional packages like WRF, LROSE, or, as we've recently seen, potentially even the GPU enabled images. If we aren't careful, our worker nodes can begin to experience disk pressure.

As of the time of this PR, the minimal notebook has a footprint of 1.58GB, while the scipy notebook uses 4.19GB of storage. This is based on pulling the images into local storage, not the compressed sizes reported on Dockerhub. If we're basing our own jupyterlab images on scipy-notebook, this causes the image to get even larger.

However it seems like changing to the minimal-notebook has allowed some things we'd taken for granted to slip through the cracks. In particular I'm referring to ipywidgets and the jupyterlab-git extension, although I'm sure this isn't an exhaustive list.

We should decide on which of these two trade offs is the lesser of two evils:
1. Larger image sizes, but we have a lot of niceties pre-installed (the subject of this PR)
2. Smaller image sizes, but some things may slip through the cracks