### PR TITLE
Fix storage allocated per user

### DIFF
--- a/jupyter-images/gpu/gpu/jupyterhub_gpu.yaml
+++ b/jupyter-images/gpu/gpu/jupyterhub_gpu.yaml
@@ -23,7 +23,7 @@ singleuser:
     limit: 1
   storage:
     type: dynamic
-    capacity: 1Gi
+    capacity: 10Gi
   # default is 300s, sometimes Jetstream volumes are slow to attach
   startTimeout: 600
   # See https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream/issues/38


### PR DESCRIPTION
@julienchastang 

Our install script reads:

```
helm upgrade --install $RELEASE jupyterhub/jupyterhub \
      ... \
      --values secrets.yaml \
      --values gpu/jupyterhub_gpu.yaml
```

While `secrets.yaml` has the correct 10GB of storage allocated per user, the gpu specific config had 1GB allocated. Since those values are included last, the 1GB value overrode the 10GB one. I'm not sure if this "order of operations" is intentional, but in case it's not, we may be overriding other values by including the gpu specific config last.