### PR TITLE
redo cert-manager

### DIFF
--- a/.org/vms/jupyter/readme.org
+++ b/.org/vms/jupyter/readme.org
@@ -142,13 +142,39 @@ Sometimes when working with the Kubernetes cert-manager, you can get yourself in
 
 #+begin_src shell
   kubectl delete namespace cert-manager
-  kubectl delete -f \
-          https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
+  kubectl delete clusterissuer letsencrypt
+  kubectl delete certificates --all --all-namespaces
+  kubectl delete certificaterequests.cert-manager.io --all --all-namespaces
 #+end_src
 
-with the version ~vX.Y.Z~ you installed.
+As of this writing, ensure the ~deploymentPatch.yml~ looks like:
 
-At that point, you can try the certificate installation again.
+#+begin_src yaml
+  # deploymentPatch.yml referenced in deploymentPatch.sh
+  ---
+  spec:
+    template:
+      spec:
+        nodeSelector:
+          "node-role.kubernetes.io/control-plane": ""
+        tolerations:
+          - key: "node-role.kubernetes.io/master"
+            operator: "Exists"
+            effect: "NoSchedule"
+          - key: "node-role.kubernetes.io/control-plane"
+            operator: "Exists"
+            effect: "NoSchedule"
+#+end_src
+
+Then you can redo the cert-manger with:
+
+#+begin_src shell
+  kubectl apply -f \
+          https://github.com/cert-manager/cert-manager/releases/download/v<version>/cert-manager.yaml
+  bash setup_https/deploymentPatch.sh
+  kubectl create -f setup_https/https_cluster_issuer.yml
+  bash install_jhub.sh
+#+end_src
 
 *** OAuth Authentication
   :PROPERTIES:

--- a/vms/jupyter/readme.md
+++ b/vms/jupyter/readme.md
@@ -185,13 +185,39 @@ Sometimes when working with the Kubernetes cert-manager, you can get yourself in
 
 ```shell
 kubectl delete namespace cert-manager
-kubectl delete -f \
-        https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
+kubectl delete clusterissuer letsencrypt
+kubectl delete certificates --all --all-namespaces
+kubectl delete certificaterequests.cert-manager.io --all --all-namespaces
 ```
 
-with the version `vX.Y.Z` you installed.
+As of this writing, ensure the `deploymentPatch.yml` looks like:
 
-At that point, you can try the certificate installation again.
+```yaml
+# deploymentPatch.yml referenced in deploymentPatch.sh
+---
+spec:
+  template:
+    spec:
+      nodeSelector:
+        "node-role.kubernetes.io/control-plane": ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+```
+
+Then you can redo the cert-manger with:
+
+```shell
+kubectl apply -f \
+        https://github.com/cert-manager/cert-manager/releases/download/v<version>/cert-manager.yaml
+bash setup_https/deploymentPatch.sh
+kubectl create -f setup_https/https_cluster_issuer.yml
+bash install_jhub.sh
+```
 
 
 <a id="h-8A3C5434"></a>


### PR DESCRIPTION
cc @ana-v-espinoza @zonca this is motivated by the fact that we are seeing some letsencrypt certs not autorenewing.  I believe this has something to do with [not needing and then needing again the letsencrypt deployment patch](https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream/issues/75). Reapplying the deployment patch did not work. The only solution I have found is this "do over" workflow. The deployment patch I propose here is slightly different from what we have discussed before, but I am not sure that matters. I find this taints and toleration business most confusing. 