### PR TITLE
Users added via admin page can now login

### DIFF
--- a/jupyter-images/shared/secrets.yaml
+++ b/jupyter-images/shared/secrets.yaml
@@ -7,6 +7,8 @@ hub:
       #If you have a large list of users, consider using allowed_users.yaml
       allowed_users:
         - users
+      # necessary for jhub admins to add user via admin page `<url>/hub/admin`
+      allow_existing_users: true
     GitHubOAuthenticator:
       client_id: "xxx"
       client_secret: "xxx"


### PR DESCRIPTION
https://discourse.jupyter.org/t/jupyterhub-on-k8s-403-forbidden-for-users-added-via-admin-page-but-not-the-helm-chart-config/26324

CC: @julienchastang @dcamron

@zonca

Julien and I ran into a problem where users that were added by admins at `<hub-url>/hub/admin` were unable to login to the JupyterHub (403 Forbidden). This, of course, is a change from the previous behavior we've come to expect. See the above link for some brief discussion about the solution found in this PR.

We know of at least one other group who had ran into this problem a couple of weeks ago, so it may be worth making an addition to your [most recent blog post](https://www.zonca.dev/posts/2023-10-27-jupyterhub-github-authentication) regarding GitHub authentication (although this is not strictly a GitHubOAuthenticator problem, I think) to disseminate this information to the wider JS2 community.