### PR TITLE
Allow for white space in kernelspec regex

### DIFF
--- a/jupyter-images/shared/default_kernel.py
+++ b/jupyter-images/shared/default_kernel.py
@@ -41,7 +41,7 @@ def update_kernelspec_in_notebooks(directory, new_name):
             # (including nested structures), preserving the overall structure
             # and formatting of the file.
             updated_contents = re.sub(
-                r'"kernelspec": \{.*?\}',
+                r'"kernelspec": *\{.*?\}',
                 f'"kernelspec": {updated_kernelspec}',
                 file_contents, flags=re.DOTALL
             )


### PR DESCRIPTION
Before this fix, updating the kernelspec would fail if there was no whitespace after the colon following "kernelspec", e.g. if the JSON was minified