### PR TITLE
more obvious prompt

### DIFF
--- a/openstack/.bashrc
+++ b/openstack/.bashrc
@@ -45,3 +45,5 @@ worker ()
   kubectl get nodes -o wide
  fi
 }
+
+export PS1='\[\e[1;32m\]❯\[\e[1;31m\] ($CLUSTER) \[\e[1;34m\]\w\[\e[0m\] ➜ '


### PR DESCRIPTION
cc: @ana-v-espinoza let me know what you think. I tried to design a better prompt to better know what cluster we are working on. Example:

```
❯ (fit25s) ~/jupyterhub-deploy-kubernetes-jetstream ➜
```

There's some color in there too that is not shown. E.g., the $CLUSTER is in red.